### PR TITLE
i2: re-enable soft support for movement to dashDB

### DIFF
--- a/server/connectors/salesforce/index.js
+++ b/server/connectors/salesforce/index.js
@@ -21,7 +21,7 @@ var _ = require('lodash');
  */
 function sfConnector( parentDirPath ){
 	//Call constructor from super class
-	connectorExt.call(this, "SalesForce", "SalesForce", {copyToDashDb: false});
+	connectorExt.call(this, "SalesForce", "SalesForce");
 	
 	this.doConnectStep = function( done, pipeRunStep, pipeRunStats, logger, pipe, pipeRunner ){
 		var sfConnection = pipeRunner.sf;


### PR DESCRIPTION
Salesforce: removed explicitly set copyToDashDb: false (ConnectorEx uses true as default)
Stripe: added conditional code for dash-specific steps (Change was not implemented in Connector because custom connectors can add any type of steps)
